### PR TITLE
fix: more strict regex for installation command

### DIFF
--- a/commands/install.ts
+++ b/commands/install.ts
@@ -31,8 +31,8 @@ export default class Install extends BaseCommand {
     const envExampleContents = await readFile('.env.example', 'utf-8')
     let envContents = envExampleContents
     for (const [key, value] of Object.entries(environmentVariables)) {
-      envContents = envContents.replace(new RegExp(`${key}=.*`), `${key}=${value}`)
-      envContents = envContents.replace(new RegExp(`# ${key}=`), `${key}=`)
+      envContents = envContents.replace(new RegExp(`^${key}=.*$`, 'm'), `${key}=${value}`)
+      envContents = envContents.replace(new RegExp(`^# ${key}=$`, 'm'), `${key}=`)
     }
     await writeFile('.env', envContents)
   }


### PR DESCRIPTION
When you run `node ace install` the command will configure your `.env` file based on `.env.example`

But when the program replace the `DRIVER` var with the new value it will not replace this var but `SESSION_DRIVER` because of the regex that is not so specific.

This pr just improve the Regex and fix the issue